### PR TITLE
Fixing implementation of add_name_alias

### DIFF
--- a/src/adapters/fake/adapter.rs
+++ b/src/adapters/fake/adapter.rs
@@ -73,8 +73,8 @@ impl HostAdapter for FakeAdapter {
         format!("{}-2", host_name)
     }
 
-    fn add_name_alias(&self, host_name: &str) -> String {
-        host_name.to_owned()
+    fn add_name_alias(&self, host_name: &str) {
+        warn!("Host name change request (-> {}) will be ignored.", host_name);
     }
 }
 


### PR DESCRIPTION
_add_name_alias_ had the wrong implementation. This was breaking non-Linux builds which are using the fake adapter.

See https://github.com/fxbox/foxbox/issues/120.
